### PR TITLE
Fix flaky mesure.sh

### DIFF
--- a/measure.sh
+++ b/measure.sh
@@ -29,12 +29,22 @@ wait_for_query_value() {
     until [ "$result" -eq 1 ]
     do
         sleep 10
+        limitOfRetries=0
         value=$(curl -s $url -d "query=$1" -H "Authorization: Bearer $token" | jq ' try .data.result[0].value[1] | tonumber')
         until [ ! -z "$value" ]
         do
+
+          # tries to query the endpoint for a maximum of 5 minutes
+          if [ $limitOfRetries -eq 30 ]
+          then
+            echo "Error querying endpoint $url"
+            exit 1
+          fi
+
           echo "Failed to query to endpoint $url, retrying..."
           sleep 10
           value=$(curl -s $url -d "query=$1" -H "Authorization: Bearer $token" | jq 'try .data.result[0].value[1] | tonumber')
+          ((limitOfRetries=limitOfRetries+1))
         done
         result=$(echo "$value $2 $3" | bc)
         printf "\r %g %s %g: %s" "$value" "$2" "$3" "$result"

--- a/measure.sh
+++ b/measure.sh
@@ -28,8 +28,14 @@ wait_for_query_value() {
 
     until [ "$result" -eq 1 ]
     do
-        sleep 30
-        value=$(curl -s $url -d "query=$1" -H "Authorization: Bearer $token" | jq '.data.result[0].value[1] | tonumber')
+        sleep 10
+        value=$(curl -s $url -d "query=$1" -H "Authorization: Bearer $token" | jq ' try .data.result[0].value[1] | tonumber')
+        until [ ! -z "$value" ]
+        do
+          echo "Failed to query to endpoint $url, retrying..."
+          sleep 10
+          value=$(curl -s $url -d "query=$1" -H "Authorization: Bearer $token" | jq 'try .data.result[0].value[1] | tonumber')
+        done
         result=$(echo "$value $2 $3" | bc)
         printf "\r %g %s %g: %s" "$value" "$2" "$3" "$result"
     done


### PR DESCRIPTION
This issue is likely caused by the request to the endpoint is happening before the information being available.

```
Waiting for minimal throughput
jq: error (at <stdin>:0): null (null) cannot be parsed as a number
Error: Process completed with exit code 5.
```

The error that we find in this script is that we are trying to parse a null value, the request-response body in this case.

One solution could be to increase the sleep timer before this request happens.
Another one that was used here is to retry the endpoint until the request-response body is no longer null.

Closes #7 