### PR TITLE
Fix the endpoint to query prometheus and query retries if data not available in measure.sh #7

### DIFF
--- a/measure.sh
+++ b/measure.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 set -o errexit
 
-url=https://monitoring.googleapis.com/v1/projects/zeebe-io/location/global/prometheus/api/v1/query
+url=http://localhost:8001/api/v1/namespaces/monitoring/services/monitoring-kube-prometheus-prometheus:http-web/proxy/api/v1/query
 token=$(gcloud auth print-access-token)
+
+# open the proxy in the background
+kubectl proxy &
 
 # Query helpers
 percentile() {
@@ -92,3 +95,6 @@ fi
 
 echo "Process Instance Execution Time: p99=$process_latency_99 p90=$process_latency_90 p50=$process_latency_50"
 echo "Throughput: $throughput_avg PI/s"
+
+# kills the proxy listening on port 8001
+kill $(lsof -i tcp:8001 -t)

--- a/measure.sh
+++ b/measure.sh
@@ -2,7 +2,6 @@
 set -o errexit
 
 url=http://localhost:8001/api/v1/namespaces/monitoring/services/monitoring-kube-prometheus-prometheus:http-web/proxy/api/v1/query
-token=$(gcloud auth print-access-token)
 
 trap 'jobs -p | xargs -r kill -TERM' INT TERM EXIT HUP
 


### PR DESCRIPTION
Currently in the CI pipeline the measure.sh was failing constantly due to the endpoint where we query the Prometheus data had been changed, but not updated in this script.

```
Waiting for minimal throughput
jq: error (at <stdin>:0): null (null) cannot be parsed as a number
Error: Process completed with exit code 5.
The error that we find in this script is that we are trying to parse a null value, the request-response body in this case.
```

Also before the change of the endpoint, there were some occasional runs where the script would fail randomly probably due to a race condition of the query happening before the data being available right after the creation of the benchmark.

One solution could be to increase the sleep timer before this request happens.
Another one that was used here is to retry the endpoint until the request-response body is no longer null.

Closes https://github.com/zeebe-io/zeebe-performance-test/issues/7